### PR TITLE
UPD [privx] fixes and improvements for helm chart

### DIFF
--- a/charts/privx/Chart.yaml
+++ b/charts/privx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 20.0.0
+version: 20.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/privx/configs/privx/settings/shared-config.toml
+++ b/charts/privx/configs/privx/settings/shared-config.toml
@@ -214,7 +214,7 @@ host = "{{ .Values.db.address }}"
 
 # Port number of the database
 # i.e. port = 5432
-port = "{{ .Values.db.port }}"
+port = {{ .Values.db.port }}
 
 # Driver name, i.e. postgres, mysql, ora
 # i.e. driver = "postgres"

--- a/charts/privx/templates/configmaps.yaml
+++ b/charts/privx/templates/configmaps.yaml
@@ -1,5 +1,9 @@
 {{- $globalContext := . }}
-{{- range $config := .Values.configs}}
+{{- $configs := .Values.configs }}
+{{- if .Values.migration.enabled }}
+{{- $configs = .Values.migration.configs }}
+{{- end }}
+{{- range $config := $configs }}
 {{- $files := $config.files -}}
 apiVersion: v1
 kind: ConfigMap
@@ -11,6 +15,9 @@ metadata:
 data:
 {{ range $path, $d :=  $globalContext.Files.Glob  $files }}
   {{ base ($path | toString) }}: |+
+  {{- if and (not $globalContext.Values.migration.enabled) (contains "toml" (base ($path | toString))) (not (contains "version" (base ($path | toString)))) }}
+    {{ printf "version = %s" (regexFind "\\d+\\.\\d+" $globalContext.Chart.AppVersion | quote) }}
+  {{ end }}
   {{- tpl ($d | toString | nindent 4) $globalContext }}
 {{ end }}
 ---

--- a/charts/privx/templates/deployment.yaml
+++ b/charts/privx/templates/deployment.yaml
@@ -7,8 +7,12 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "privx.name" $globalContext }}-{{ $service.name }}
 spec:
-  {{- if not $service.autoscaling.enabled }}
+  {{- if or (not $service.autoscaling.enabled) $globalContext.Values.shutdown }}
+  {{- if $globalContext.Values.shutdown }}
+  replicas: 0
+  {{- else }}
   replicas: {{ $service.replicaCount }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/privx/values.yaml
+++ b/charts/privx/values.yaml
@@ -46,6 +46,13 @@ privx:
     #admin email for PrivX UI login (required)
     email:
 
+# When enabled migration will do the backup + upgrade (while using the correct override values)
+migration:
+  enabled: false
+
+# Enabling shutdown will bring all the deployment replicas to zero
+shutdown: false
+
 #==============Config values (TOMLS, RDPMITM and NGINX configs)
 configs:
   nginx:


### PR DESCRIPTION
- The db port in the shared-config.toml should be an integer instead of a string
- Migration configs should be created separately from the one in initial install
- All of the privx configs should get the PrivX version from the Chart.AppVersion (Only MM.mm format is used )
- A shutdown switch is added which brings down all the Privx microservices (Kubernetes Deployments).