### PR TITLE
ADD [ingress] secure ingress overrides file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ helm install \
     -f values-overrides/ingress.yaml \
     ingress charts/nginx-ingress-controller/
 ```
+#### Restricted access Ingress Controller
+
+If the ingress controller is deployed in a more secure fashion, then the
+following command can be used:
+
+**NOTE: The pre-requisite for using the command is to have a volume claim named
+`ingress-claim`**
+
+```
+helm upgrade --install \
+    -n ingress --create-namespace \
+    -f values-overrides/ingress.yaml \
+    -f values-overrides/ingress-secure.yaml \
+    ingress charts/nginx-ingress-controller/
+```
+
+The command above uses an extra override file called
+[ingress-secure.yaml](values-overrides/ingress-secure.yaml).
+
+The file restricts privilege escalation, writing to container
+filesystem and drops all file capabilities including the `NET_BIND_SERVICE`
+that is needed by the ingress controller. The last setting is dropped with the
+help of a wrapper container around the Bitnami Ingress Controller Docker container
+by dropping the file capability `cap_net_bind_service`.
 
 ### Working Postgres Database
 

--- a/values-overrides/ingress-secure.yaml
+++ b/values-overrides/ingress-secure.yaml
@@ -1,0 +1,84 @@
+image:
+  registry: public.ecr.aws
+  repository: sshprivx/nginx-ingress
+  tag: "20.0"
+
+
+# Change the default ports 80 and 443 to be something > 1024
+extraArgs:
+  http-port: 18080
+  https-port: 19443
+
+containerPorts:
+  http: 18080
+  https: 19443
+
+containerSecurityContext:
+  enabled: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsUser: 1001
+  capabilities:
+    add: []
+    drop: ["ALL"]
+
+# Volumes and volume mounts are needed because of the `readOnlyRootFilesystem`
+# setting
+extraVolumes:
+  - name: ingress-mount
+    persistentVolumeClaim:
+      claimName: ingress-claim
+
+extraVolumeMounts:
+  - mountPath: /etc/ingress-controller/ssl/
+    name: ingress-mount
+    subPath: bitnamissl
+  - mountPath: /tmp
+    name: ingress-mount
+    subPath: bitnamitmp
+  - mountPath: /etc/nginx/
+    name: ingress-mount
+    subPath: bitnamietcnginx
+
+# Copy all the files from the container to the volume mount and copy them
+# back so that there is no writing to the container filesystem
+initContainers:
+  - name: conf-copier-1
+    image: public.ecr.aws/sshprivx/nginx-ingress:20.0
+    imagePullPolicy: IfNotPresent
+    command: [ "/bin/sh", "-c" ]
+    securityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1001
+      allowPrivilegeEscalation: false
+    args:
+      - echo copying nginx template;
+        cp -rf /etc/nginx/* /temporaryconf/;
+    volumeMounts:
+    - mountPath: /temporaryconf
+      name: ingress-mount
+      subPath: temporaryconf
+  - name: conf-copier-2
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    command: [ "/bin/sh", "-c" ]
+    securityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1001
+      allowPrivilegeEscalation: false
+    args:
+      - echo copying temporaryconf to nginx template;
+        cp -rf /temporaryconf/* /etc/nginx/;
+    volumeMounts:
+    - mountPath: /temporaryconf
+      name: ingress-mount
+      subPath: temporaryconf
+    - mountPath: /etc/nginx
+      name: ingress-mount
+      subPath: bitnamietcnginx
+
+# switch off the default backend so that it doesn't require any security contexts
+defaultBackend:
+  enabled: false


### PR DESCRIPTION
 - An extra override file is provided for ingress
   controller so that the security context of nginx
   can be limited.

 - The security context forbids priviledge escalation,
   writing to the container file system and drops
   all priviledged file capabilities (namely:
   NET_BIND_SERVICE)

 - A volume claim named 'ingress-claim' is required
   so that the containers don't write to the container
   file system directly

 - The image used for ingress controller is a wrapper
   around the bitnami nginx ingress controller image
   with NET_BIND_SERVICE removed