### PR TITLE
UPD [kube] modify ingress cont installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ privx-kube is a means to deploy [PrivX](https://www.ssh.com/products/privx/) in
 a kubernetes cluster.
 
 ## Introduction
-This repo contains the PrivX chart and in addition uses [Bitnami Nginx Ingress
-Controller](https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller). The purpose of the
-ingress controller is to setup ingress to the PrivX microservices in a dynamic
-way.
+This repo contains the PrivX helm chart that can be used to deploy the supported
+versions of PrivX on Kubernetes.
 
 ## Prequisites
 
@@ -40,7 +38,13 @@ for PrivX to work.
 
 ### Ingress Controller
 
-privx-kube provides a file [ingress.yaml](values-overrides/ingress.yaml) with
+As in any kubernetes cluster, a gateway or ingress is required to reach the
+application. PrivX uses [Bitnami Nginx Ingress Controller](https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller)
+as the ingress controller.
+
+The purpose of the ingress controller is to setup ingress to the PrivX
+microservices in a dynamic way.
+privx-kube provides an override file [ingress.yaml](values-overrides/ingress.yaml) with
 extra settings for deploying the Bitnami nginx ingress controller. The purpose
 of the file is to provide settings that are crucial to the workings of PrivX.
 
@@ -49,14 +53,36 @@ settings (e.g Load balancer settings). But the main requirement after installing
 the ingress controller is that it should be accessible for the clients that
 would end up using PrivX.
 
+The installation instructions are split in to two sections depending on the
+version of Kubernetes in use =1.19 or >1.19. This is because of the backward
+incompatible changes done by the developers of the ingress controller helm chart.
 To install the ingress controller chart, do the following:
 
+
+##### Kubernetes =1.19:
 ```
+helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
 helm install \
     -n ingress --create-namespace \
     -f values-overrides/ingress.yaml \
-    ingress charts/nginx-ingress-controller/
+    --version 7.6.6 \
+    ingress  bitnami-full-index/nginx-ingress-controller
 ```
+
+##### Kubernetes >1.19:
+```
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install \
+    -n ingress --create-namespace \
+    -f values-overrides/ingress.yaml \
+    --version 9.3.8 \
+    ingress  bitnami-full-index/nginx-ingress-controller
+```
+
+Up to date instructions on new releases and any breaking changes can be found
+in the original
+[repo](https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller#upgrading).
+
 #### Restricted access Ingress Controller
 
 If the ingress controller is deployed in a more secure fashion, then the

--- a/charts/privx/Chart.yaml
+++ b/charts/privx/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 25.0.0
+version: 25.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "25.0.0"
+appVersion: "25.0.1"

--- a/charts/privx/templates/ingress.yaml
+++ b/charts/privx/templates/ingress.yaml
@@ -31,8 +31,12 @@ metadata:
     {{- end }}
   {{- end}}
 spec:
-  {{- if and $ingress.className (semverCompare ">=1.18-0" $globalContext.Capabilities.KubeVersion.GitVersion) }}
+  {{- if and (or $ingress.className $globalContext.Values.ingress.common.className) (semverCompare ">=1.18-0" $globalContext.Capabilities.KubeVersion.GitVersion) }}
+    {{- if $ingress.className }}
   ingressClassName: {{ $ingress.className }}
+    {{- else }}
+  ingressClassName: {{ $globalContext.Values.ingress.common.className }}
+    {{- end }}
   {{- end }}
   {{- if $ingress.tls }}
   tls:

--- a/charts/privx/values.yaml
+++ b/charts/privx/values.yaml
@@ -5,6 +5,7 @@ fullnameOverride: ""
 nameOverride: ""
 ingress:
   common:
+    className: "nginx"
     host: localhost
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"


### PR DESCRIPTION
 - Bitnami ingress controller 7.X.X is not compatible with latest kubernetes versions and the latest ingress controller doesn't support kuberetes v1.19.

 - Separate instructions are added to install the ingress controller on either 1.19 or >1.19 clusters.

 - PrivX chart is also modified to support the new ingressClassName object in the ingress resource.